### PR TITLE
Replace char::MIN with '\0'.

### DIFF
--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -118,7 +118,7 @@ impl ExprSet {
 
         if !self.any_unicode.is_valid()
             && ranges.len() == 1
-            && ranges[0].start() == char::MIN
+            && ranges[0].start() == '\0'
             && ranges[0].end() == char::MAX
         {
             self.any_unicode = r;
@@ -126,7 +126,7 @@ impl ExprSet {
 
         if !self.any_unicode_non_nl.is_valid()
             && ranges.len() == 2
-            && ranges[0].start() == char::MIN
+            && ranges[0].start() == '\0'
             && ranges[0].end() == (b'\n' - 1) as char
             && ranges[1].start() == (b'\n' + 1) as char
             && ranges[1].end() == char::MAX


### PR DESCRIPTION
[`char::MIN` is unstable for Rust < 1.83](https://doc.rust-lang.org/std/primitive.char.html#associatedconstant.MIN). This causes [Chromium builds to fail in Ubuntu](https://launchpadlibrarian.net/789691133/buildlog_snap_ubuntu_noble_amd64_chromium-snap-from-source-dev_BUILDING.txt.gz). Rust 1.83 is not available in any current Ubuntu LTS, and I imagine other Linux distributors would encounter the same problem, so I'd like to suggest this little rewrite.