### PR TITLE
[Build] Bumping versions & triggers

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,7 +15,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - run: cargo fmt --check
     - run: cargo clippy --all-targets --all-features -- -D warnings
     - name: Build
@@ -27,7 +27,7 @@ jobs:
     name: MSRV Check
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Rust
       uses: dtolnay/rust-toolchain@1.80.0
       with:
@@ -43,7 +43,7 @@ jobs:
     environment: pkg
     needs: [build]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Publish to crates.io
         run: cargo publish
         env:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -42,6 +42,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
+      with:
+        ref: ${{ github.event_name == 'workflow_dispatch' && inputs.commit_id || github.sha }}
     - name: Set up Rust
       uses: dtolnay/rust-toolchain@1.87.0
       with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -7,6 +7,16 @@ on:
       - 'v*'
   pull_request:
     branches: [ "main" ]
+  workflow_dispatch:
+    inputs:
+      commit_id:
+        description: 'Branch or Commit ID (optional)'
+        required: false
+        type: string
+  schedule:
+    # * is a special character in YAML so we quote this string
+    # Run at 09:20 UTC every day
+    - cron:  '20 09 * * *'
 
 env:
   CARGO_TERM_COLOR: always
@@ -14,8 +24,12 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    with:
+      ref: ${{ github.event_name == 'workflow_dispatch' && inputs.commit_id || github.sha }}
     steps:
     - uses: actions/checkout@v6
+      with:
+        ref: ${{ github.event_name == 'workflow_dispatch' && inputs.commit_id || github.sha }}
     - run: cargo fmt --check
     - run: cargo clippy --all-targets --all-features -- -D warnings
     - name: Build
@@ -29,7 +43,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
     - name: Set up Rust
-      uses: dtolnay/rust-toolchain@1.80.0
+      uses: dtolnay/rust-toolchain@1.87.0
       with:
         components: clippy
     - run: cargo build --verbose --locked

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,8 +24,6 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
-    with:
-      ref: ${{ github.event_name == 'workflow_dispatch' && inputs.commit_id || github.sha }}
     steps:
     - uses: actions/checkout@v6
       with:


### PR DESCRIPTION
Bump the version of the `checkout` action to get rid of Node v20 warnings. Also add some extra triggers so we run the workflow somewhat frequently