### PR TITLE
Fix Expr::Byte serialization on big-endian platforms

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -252,7 +252,8 @@ impl<'a> Expr<'a> {
         match tag {
             ExprTag::EmptyString => Expr::EmptyString,
             ExprTag::NoMatch => Expr::NoMatch,
-            ExprTag::Byte => Expr::Byte(s[1] as u8),
+            // stored as LE so get_bytes() can read it via cast_slice on any platform
+            ExprTag::Byte => Expr::Byte(u32::from_le(s[1]) as u8),
             ExprTag::ByteSet => Expr::ByteSet(&s[1..]),
             ExprTag::Lookahead => Expr::Lookahead(flags, ExprRef::new(s[1]), s[2]),
             ExprTag::Not => Expr::Not(flags, ExprRef::new(s[1])),
@@ -299,7 +300,8 @@ impl<'a> Expr<'a> {
                 ]);
             }
             Expr::Byte(b) => {
-                trg.push_slice(&[flags.encode(ExprTag::Byte), *b as u32]);
+                // store as LE so get_bytes() can read it via cast_slice on any platform
+                trg.push_slice(&[flags.encode(ExprTag::Byte), (*b as u32).to_le()]);
             }
             Expr::ByteSet(s) => {
                 trg.push_u32(flags.encode(ExprTag::ByteSet));


### PR DESCRIPTION
`Expr::Byte` stores its value as a `u32` in the backing `Vec<u32>`, but `get_bytes()` reads it back via `bytemuck::cast_slice` as `&[u8]` and returns `bslice[0]`. On little-endian, byte 0 of `u32(0x61)` is `0x61`. On big-endian, byte 0 is `0x00` — the value is at byte 3 instead.

This corrupts regex compilation: the simplifier's `ConcatIter` calls `get_bytes()` to convert `Byte` exprs into `ByteConcat`, so patterns like `a[bc]` become `\0[bc]` on big-endian.

Fix: store with `u32::to_le()`, read with `u32::from_le()`. This places the byte at memory offset 0 on all platforms. No-op on LE, single `bswap` on BE.

Verified by cross-compiling and running the test suite on `s390x-unknown-linux-gnu` via `cross`/QEMU — 7 of 14 `basic` tests were failing before this fix; all pass after.

Possibly related to https://github.com/guidance-ai/llguidance/issues/330, though the fix has not been confirmed end-to-end on real s390x hardware. No plans to add s390x to CI at this time.