### PR TITLE
Add version constant to lib.rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,3 +35,5 @@ pub mod raw {
     pub use super::nextbyte::NextByteCache;
     pub use super::relevance::RelevanceCache;
 }
+
+pub const VERSION: &str = concat!("derivre@", env!("CARGO_PKG_VERSION"));


### PR DESCRIPTION
Puts the library version into lib.rs as a const which can be referenced downstream. This change is needed for this llguidance PR: https://github.com/guidance-ai/llguidance/pull/334